### PR TITLE
Add playing with a segfault

### DIFF
--- a/programming_languages/cpp/segfault/x86_64_recovery.cpp
+++ b/programming_languages/cpp/segfault/x86_64_recovery.cpp
@@ -1,0 +1,45 @@
+#include "signal.h"
+#include <vector>
+#include <iostream>
+
+// TODO(gitbuda): Try to make the following work on x86_64
+// https://feepingcreature.github.io/handling.html
+
+void seghandle_userspace() {
+  *(int*) NULL = 0;
+}
+
+// TODO(gitbuda): Make it complete and correct.
+enum X86Registers {
+  RSP = 15,
+  RIP = 16,
+};
+
+void seghandle(int sig, siginfo_t* si, void* unused) {
+  ucontext_t* uc = (ucontext_t*) unused;
+  auto gregs = uc->uc_mcontext.gregs;
+  void* eip = (void*) gregs[X86Registers::RIP];
+  void** esp = (void**) gregs[X86Registers::RSP];
+  esp --;
+  *esp = eip;
+  eip = (void*) &seghandle_userspace;
+}
+
+void setup_segfault_handler() {
+  struct sigaction sa;
+  sa.sa_flags = SA_SIGINFO;
+  sigemptyset (&sa.sa_mask);
+  sa.sa_sigaction = &seghandle;
+  if (sigaction(SIGSEGV, &sa, NULL) == -1) {
+    fprintf(stderr, "failed to setup SIGSEGV handler\n");
+    std::exit(1);
+  }
+}
+
+int main() {
+  // TODO(gitbuda): The program hangs figure out why :thinking:
+  setup_segfault_handler();
+  std::vector<int> nums;
+  std::cout << nums[1] << std::endl;
+  return 0;
+}


### PR DESCRIPTION
### References
* https://feepingcreature.github.io/handling.html
* https://wiki.cdot.senecacollege.ca/wiki/X86_64_Register_and_Instruction_Quick_Start
* https://stackoverflow.com/questions/70258418/why-is-a-segmentation-fault-not-recoverable "Because the OS doesn’t know what your program is supposed to be doing." -> I would also, your program doesn't know what it is supposed to be doing, it can be in a complex undefined state.
* https://stackoverflow.com/questions/1753602/what-are-the-names-of-the-new-x86-64-processors-registers
* https://stackoverflow.com/questions/8401689/best-practices-for-recovering-from-a-segmentation-fault
* https://stackoverflow.com/questions/2350489/how-to-catch-segmentation-fault-in-linux
* https://github.com/Plaristote/segvcatch

### Conclusion

Dealing with SEGFAULT is hard/almost_imposible in general case, you can maybe handle only specific cases.